### PR TITLE
.end() method to disconnect from websocket stream 

### DIFF
--- a/src/ESPSupabaseRealtime.h
+++ b/src/ESPSupabaseRealtime.h
@@ -65,6 +65,7 @@ public:
   void addChangesListener(String table, String event, String schema, String filter);
   void listen();
   void loop();
+  void end(); // A way to end the websocket process (if realtime.loop() is called it will reconnect automatically)
   int login_email(String email_a, String password_a);
   int login_phone(String phone_a, String password_a);
 };

--- a/src/Realtime.cpp
+++ b/src/Realtime.cpp
@@ -211,6 +211,11 @@ void SupabaseRealtime::begin(String hostname, String key, void (*func)(String))
   this->handler = func;
 }
 
+void SupabaseRealtime::end()
+{
+  webSocket.disconnect();
+}
+
 int SupabaseRealtime::login_email(String email_a, String password_a)
 {
   useAuth = true;


### PR DESCRIPTION
While the websocket stream was blocking every other connection I implemented an end() method.
With this it is possible to pause the stream and do some CRUD operations before it is automatically continued.
